### PR TITLE
Dev

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,24 +1,23 @@
 {
-    "title":"LayTracer: Fast two-point seismic ray tracing in layered media",
-   "version":"0.2.1",    
-    "license":"MIT",
-    "upload_type":"software",
-   "description":"LayTracer is an open-source Python package for computing ray paths, travel times, and amplitude attributes in horizontally layered (1D) velocity models. Version 0.2.1 adds energy-flux-normalized reflection and transmission coefficient support following Červený (2001), including a new normalized transmission-coefficient option in ray tracing and solving workflows, updated examples and methodology documentation, and tests covering normalized and vertical-ray cases. The release also renames the transmission-coefficient methods for clarity and removes the former impedance-only normal-incidence option.",
-    "keywords":[
-       "Geophysics",
-       "Seismology",
-       "Ray Tracing",
-       "Layered Media"       
+    "title": "LayTracer: Fast two-point seismic ray tracing in layered media",
+    "version": "0.3.0",
+    "license": "MIT",
+    "upload_type": "software",
+    "description": "LayTracer is an open-source Python package for computing ray paths, travel times, and path-dependent scalar quantities in horizontally layered (1D) velocity models. Version 0.3.0 replaces the coarse amplitude switch with explicit requested-output selection in trace_rays() and solve(), so callers can request only the fields they need, such as travel times, rays, ray parameters, tstar, geometrical spreading, and transmission-coefficient products. The release also fixes degenerate direct-ray amplitude outputs for zero-offset vertical rays and exact same-point rays, makes scalar result packing robust to mixed None and finite values, and adds regression tests for these edge cases.",
+    "keywords": [
+        "Geophysics",
+        "Seismology",
+        "Ray Tracing",
+        "Layered Media"
     ],
-    "access_right":"open",    
-    "language":"eng",
-    "creators":[       
-       {
-          "affiliation": "Center for Integrative Petroleum Research, King Fahd University of Petroleum and Minerals, Dhahran, Saudi Arabia",
-          "name":"Anikiev, Denis",
-          "orcid":"0000-0002-4729-2659",
-          "type":"contactperson"
-       }
+    "access_right": "open",
+    "language": "eng",
+    "creators": [
+        {
+            "affiliation": "Center for Integrative Petroleum Research, King Fahd University of Petroleum and Minerals, Dhahran, Saudi Arabia",
+            "name": "Anikiev, Denis",
+            "orcid": "0000-0002-4729-2659",
+            "type": "contactperson"
+        }
     ]
- }
- 
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add explicit `requested={...}` output selection to `trace_rays()` and `solve()`, replacing the coarse amplitude switch (#2)
+
+### Changed
+
+- only build and return ray paths, ray parameters, and path-dependent scalar outputs when explicitly requested (#2)
+
 ### Fixed
 
 - fix degenerate direct-ray amplitude outputs for zero-offset vertical rays and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to Laytracer will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add explicit `requested={...}` output selection to `trace_rays()` and `solve()`, replacing the coarse amplitude switch (#2)
+- add explicit `requested={...}` output selection to `trace_rays()` and `solve()`, replacing the coarse amplitude switch (#3)
 
 ### Changed
 
-- only build and return ray paths, ray parameters, and path-dependent scalar outputs when explicitly requested (#2)
+- only build and return ray paths, ray parameters, and path-dependent scalar outputs when explicitly requested (#3)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- fix degenerate direct-ray amplitude outputs for zero-offset vertical rays and
+  exact same-point rays (#2)
+- make amplitude result packing robust to mixed `None` and finite values (#2)
+- add regression tests for degenerate direct-ray amplitude cases (#2)
+
 ## [v0.2.1] - 2026-03-07
 
 ### Added
@@ -31,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `"normal"` (impedance-only) transmission coefficient method — only
   `"standard"` and `"normalized"` are supported (#1)
 - normal-incidence section removed from methodology docs (#1)
-
 
 ## [v0.2.0] - 2026-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Laytracer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.3.0] - 2026-03-14
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ result = laytracer.trace_rays(
     sources=src,
     receivers=rcvs,
     velocity_df=vel_df,
-    vel_type="Vp",
-    compute_amplitude=True,
-    transcoef_method="standard",  # full Zoeppritz
+    source_phase="P",
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
+    transcoef_method="standard",  # standard Zoeppritz coefficients without normalization
 )
 
 # Access results

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 This project uses `setuptools_scm`, so the package version is derived from Git tags.
 Use semantic tags in the form `vX.Y.Z` (example: `v0.1.1`).
 
-## 1) One-time setup
+## 1. One-time setup
 
 Install tools:
 
@@ -35,7 +35,7 @@ username = __token__
 password = pypi-PYPI_TOKEN_HERE
 ```
 
-## 2) Standard release flow (TestPyPI first)
+## 2. Standard release flow (TestPyPI first)
 
 From repo root:
 
@@ -77,7 +77,7 @@ Upload to PyPI:
 python -m twine upload -r pypi dist/*
 ```
 
-## 3) Quick automation commands
+## 3. Quick automation commands
 
 Use these two command blocks as a repeatable release routine.
 
@@ -101,13 +101,13 @@ python -m twine upload -r testpypi dist/*
 python -m twine upload -r pypi dist/*
 ```
 
-## 4) Common errors
+## 4. Common errors
 
 - `403 Forbidden`: wrong token or wrong repository (PyPI token vs TestPyPI token).
 - `File already exists`: this version is already uploaded; bump tag/version and rebuild.
 - Unexpected dev version: release tag missing or not fetched in current Git checkout.
 
-## 5) GitHub Actions automation (`release.yml`)
+## 5. GitHub Actions automation (`release.yml`)
 
 This repository includes `.github/workflows/release.yml`.
 
@@ -144,7 +144,7 @@ Notes:
 - Publishing is guarded: only strict semver tags in the form `vMAJOR.MINOR.PATCH` are accepted (example: `v1.2.3`).
 - Upload steps use `skip-existing: true`, so reruns with the same version do not fail if files are already present.
 
-## 6) Release-event automation (`release-on-published.yml`)
+## 6. Release-event automation (`release-on-published.yml`)
 
 This repository also includes `.github/workflows/release-on-published.yml`.
 
@@ -160,7 +160,7 @@ When to use which workflow:
 - Use `release-on-published.yml` if you want publishing only after explicitly creating/publishing a GitHub Release in the UI.
 - Both workflows enforce strict semver tags (`vMAJOR.MINOR.PATCH`) before build/publish jobs run.
 
-## 7) Zenodo release plan (recommended order)
+## 7. Zenodo release plan (recommended order)
 
 Use this checklist to publish a citable Zenodo record for each tagged release.
 

--- a/examples/03_reflection_transmission.py
+++ b/examples/03_reflection_transmission.py
@@ -63,24 +63,24 @@ RT = lt.psv_rt_coefficients(
 # ----------------------------
 #
 # For an incident P-wave the ray parameter sweeps from 0 to
-# :math:`1/V_P` (grazing P incidence), covering the full 0–90° range.
+# :math:`1/V_P` (grazing P incidence), covering the full :math:`0--90^{\circ}` range.
 #
 # **Critical angle** (dashed red line):
 #
 # * Transmitted P becomes evanescent at
-#   :math:`\theta_c^{T(P)} = \arcsin(V_P^{(1)}/V_P^{(2)}) \approx 38.5°`.
+#   :math:`\theta_c^{T(P)} = \arcsin(V_P^{(1)}/V_P^{(2)}) \approx 38.5^{\circ}`.
 #   Beyond this angle :math:`|R_{PP}| \to 1` (total reflection).
 #   There is no transmitted-SV critical angle because
 #   :math:`V_P^{(1)} > V_S^{(2)}` for this model.
 #
 # **Brewster angles** (dotted purple lines):
 #
-# * :math:`|R_{PS}|` has a near-zero at ≈37.9°, just before the
+# * :math:`|R_{PS}|` has a near-zero at :math:`37.9^{\circ}`, just before the
 #   critical angle.  This is the P-to-SV mode-conversion null,
 #   analogous to the optical Brewster angle.  Its position depends
 #   on all six elastic parameters, not just the velocity ratio.
 
-# Incidence angle (P-wave): θ = arcsin(p · Vp)
+# Incidence angle (P-wave): :math:`\theta` = \arcsin{p \cdot V_p}`
 angle_P = np.rad2deg(np.arcsin(np.clip(p_vec * mi_vp, -1, 1)))
 crit_P = np.rad2deg(np.arcsin(mi_vp / mt_vp))   # transmitted P critical
 
@@ -128,8 +128,8 @@ fig.tight_layout()
 plt.show()
 
 ###############################################################################
-# Normalized P-wave coefficients (Červený, 2001)
-# -----------------------------------------------
+# Normalized P-wave coefficients
+# ------------------------------
 #
 # Energy-flux-normalized coefficients account for the impedance and
 # directional cosine contrast across the interface.  They are useful
@@ -167,7 +167,7 @@ ymax_Pn = max(ymax_Pn, 0.5)
 
 fig, axes = plt.subplots(2, 2, figsize=(12, 9))
 fig.suptitle(
-    "Incident P-wave — normalized (Červený, 2001)\n"
+    "Incident P-wave ??? normalized (Červený, 2001)\n"
     f"Inc: Vp={mi_vp}, Vs={mi_vs}, ρ={mi_rho}  →  "
     f"Trans: Vp={mt_vp}, Vs={mt_vs}, ρ={mt_rho}",
     fontsize=11,
@@ -287,7 +287,7 @@ def plot_ray_situation(angle, wave_type, title, ax):
                 source_phase=wave_type,
                 reflection=reflection_arg,
                 refraction=refraction_arg,
-                compute_amplitude=False
+                requested={"travel_times", "rays", "ray_parameters"}
             )
             
             if res.rays and len(res.rays) > 0 and res.rays[0] is not None:
@@ -353,22 +353,22 @@ plt.show()
 # -----------------------------
 #
 # For an incident SV-wave the ray parameter sweeps from 0 to
-# :math:`1/V_S` (grazing SV incidence), covering the full 0–90° range.
+# :math:`1/V_S` (grazing SV incidence), covering the full :math:`0--90^{\circ}` range.
 #
-# **Critical angles** (coloured lines) – three distinct thresholds:
+# **Critical angles** (coloured lines) - three distinct thresholds:
 #
-# * :math:`\theta_c^{T(P)} = \arcsin(V_S^{(1)}/V_P^{(2)}) \approx 21.3°`
-#   – transmitted P goes evanescent (blue dotted)
-# * :math:`\theta_c^{R(P)} = \arcsin(V_S^{(1)}/V_P^{(1)}) \approx 35.6°`
-#   – reflected P goes evanescent (red dashed)
-# * :math:`\theta_c^{T(SV)} = \arcsin(V_S^{(1)}/V_S^{(2)}) \approx 39.1°`
-#   – transmitted SV goes evanescent (green dash-dot);
+# * :math:`\theta_c^{T(P)} = \arcsin(V_S^{(1)}/V_P^{(2)}) \approx 21.3^{\circ}`
+#   - transmitted P goes evanescent (blue dotted)
+# * :math:`\theta_c^{R(P)} = \arcsin(V_S^{(1)}/V_P^{(1)}) \approx 35.6^{\circ}`
+#   - reflected P goes evanescent (red dashed)
+# * :math:`\theta_c^{T(SV)} = \arcsin(V_S^{(1)}/V_S^{(2)}) \approx 39.1^{\circ}`
+#   - transmitted SV goes evanescent (green dash-dot);
 #   beyond this angle all energy is reflected as SV
 #   (:math:`|R_{SS}| = 1`).
 #
 # The reflected SV wave is always real (same medium, same velocity).
 #
-# **Brewster angles** (purple dotted lines) – the near-zeros of
+# **Brewster angles** (purple dotted lines) - the near-zeros of
 # :math:`|R_{SP}|` near 21° and 40°, and of :math:`|R_{SS}|` near
 # 20°, are mode-conversion nulls governed by the full elastic
 # contrast.
@@ -381,7 +381,7 @@ RT_sv = lt.psv_rt_coefficients(
     vp2=mt_vp, vs2=mt_vs, rho2=mt_rho,
 )
 
-# Incidence angle (SV-wave): θ = arcsin(p · Vs)
+# Incidence angle (SV-wave):  :math:`\theta = \arcsin(p \cdot V_s)`
 angle_SV = np.rad2deg(np.arcsin(np.clip(p_vec_sv * mi_vs, -1, 1)))
 
 # Critical angles
@@ -466,7 +466,7 @@ ymax_SVn = max(ymax_SVn, 0.5)
 
 fig, axes = plt.subplots(2, 2, figsize=(12, 9))
 fig.suptitle(
-    "Incident SV-wave — normalized (Červený, 2001)\n"
+    "Incident SV-wave - normalized (Červený, 2001)\n"
     f"Inc: Vp={mi_vp}, Vs={mi_vs}, ρ={mi_rho}  →  "
     f"Trans: Vp={mt_vp}, Vs={mt_vs}, ρ={mt_rho}",
     fontsize=11,

--- a/examples/04_amplitude_analysis.py
+++ b/examples/04_amplitude_analysis.py
@@ -71,7 +71,7 @@ result = lt.trace_rays(
     receivers=rcvs,
     velocity_df=vel_df,
     source_phase="P",
-    compute_amplitude=True,
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
     transcoef_method="standard",
 )
 
@@ -179,13 +179,13 @@ result_normalized = lt.trace_rays(
     receivers=rcvs,
     velocity_df=vel_df,
     source_phase="P",
-    compute_amplitude=True,
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
     transcoef_method="normalized",
 )
 
 fig, ax = plt.subplots(figsize=(8, 4))
 ax.plot(offsets / 1000, result.trans_product, "o-", label="Standard (Zoeppritz)", markersize=3)
-ax.plot(offsets / 1000, result_normalized.trans_product, "s-", label="Normalized (\u010cerven\u00fd)", markersize=3)
+ax.plot(offsets / 1000, result_normalized.trans_product, "s-", label="Normalized", markersize=3)
 ax.set_xlabel("Offset (km)")
 ax.set_ylabel(r"$\prod |T_k|$")
 ax.set_title("Transmission: standard vs. energy-flux-normalized")
@@ -259,7 +259,7 @@ rcvs_p = np.column_stack([offsets, np.zeros_like(offsets), np.zeros_like(offsets
 res_refr = lt.trace_rays(
     sources=src_p, receivers=rcvs_p, velocity_df=refr_df,
     source_phase="P", reflection=[(3000.0, "P")], 
-    compute_amplitude=True, transcoef_method="standard"
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}, transcoef_method="standard"
 )
 
 # Trace Category 2: Gradient (reflect off last interface ~3km)
@@ -267,7 +267,7 @@ z_reflect = grad_df["Depth"].iloc[-1]
 res_grad = lt.trace_rays(
     sources=src_p, receivers=rcvs_p, velocity_df=grad_df,
     source_phase="P", reflection=[(z_reflect, "P")],
-    compute_amplitude=True, transcoef_method="standard"
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}, transcoef_method="standard"
 )
 
 # --- 2. Advanced Visualisation ---

--- a/examples/05_homogeneous_equivalence.py
+++ b/examples/05_homogeneous_equivalence.py
@@ -64,7 +64,7 @@ import matplotlib.pyplot as plt
 # Common parameters
 # -----------------
 #
-# We use a single set of elastic constants and a fixed source–receiver
+# We use a single set of elastic constants and a fixed source-receiver
 # geometry throughout the example.
 
 VP = 5000.0       # P-wave velocity  (m/s)
@@ -121,7 +121,7 @@ print(f"Combined (T/L):   {C_a:.10e}")
 # (b) Homogeneous model via LayTracer
 # -----------------------------------
 #
-# A single-layer DataFrame — the simplest possible model.
+# A single-layer DataFrame - the simplest possible model.
 
 homo_df = pd.DataFrame({
     "Depth": [0.0],
@@ -137,7 +137,7 @@ res_h = lt.trace_rays(
     receivers=rcv,
     velocity_df=homo_df,
     source_phase="P",
-    compute_amplitude=True,
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
     transcoef_method="standard",
 )
 
@@ -171,7 +171,7 @@ ax = lt.plot.rays_2d(
     discrete_colorbar=True,
     unit="km",
 )
-ax.set_title("(b) Homogeneous model — single layer")
+ax.set_title("(b) Homogeneous model ??? single layer")
 ax.legend(loc="upper right")
 plt.show()
 
@@ -200,7 +200,7 @@ res_l = lt.trace_rays(
     receivers=rcv,
     velocity_df=layered_df,
     source_phase="P",
-    compute_amplitude=True,
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
     transcoef_method="standard",
 )
 
@@ -224,7 +224,7 @@ print(f"Combined (T/L):   {C_l:.10e}")
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # The interface at 1500 m is visible, but the ray is identical to the
-# homogeneous case — a straight line — because the two layers share the
+# homogeneous case (a straight line) because the two layers share the
 # same velocity.
 
 ax = lt.plot.rays_2d(
@@ -238,7 +238,7 @@ ax = lt.plot.rays_2d(
     discrete_colorbar=True,
     unit="km",
 )
-ax.set_title("(c) Two-layer model — identical parameters")
+ax.set_title("(c) Two-layer model - identical parameters")
 ax.legend(loc="upper right")
 plt.show()
 
@@ -347,9 +347,9 @@ print(check_df.to_string(index=False, float_format="{:.6e}".format))
 n_fail = (check_df["Status"] == "FAIL").sum()
 print(f"\nResult: {len(checks) - n_fail}/{len(checks)} checks passed.")
 if n_fail:
-    print(">>> SOME CHECKS FAILED — investigate! <<<")
+    print(">>> SOME CHECKS FAILED - investigate! <<<")
 else:
-    print("All checks passed — homogeneous equivalence confirmed.")
+    print("All checks passed - homogeneous equivalence confirmed.")
 
 #%%
 
@@ -374,7 +374,7 @@ res_h_off = lt.trace_rays(
     receivers=rcvs,
     velocity_df=homo_df,
     source_phase="P",
-    compute_amplitude=True,
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
     transcoef_method="standard",
 )
 
@@ -383,7 +383,7 @@ res_l_off = lt.trace_rays(
     receivers=rcvs,
     velocity_df=layered_df,
     source_phase="P",
-    compute_amplitude=True,
+    requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
     transcoef_method="standard",
 )
 
@@ -404,7 +404,7 @@ ax = lt.plot.rays_2d(
     discrete_colorbar=True,
     unit="km",
 )
-ax.set_title("Offset fan — homogeneous model")
+ax.set_title("Offset fan - homogeneous model")
 ax.legend(loc="lower right")
 plt.show()
 
@@ -419,7 +419,7 @@ ax = lt.plot.rays_2d(
     discrete_colorbar=True,
     unit="km",
 )
-ax.set_title("Offset fan — two-layer identical model")
+ax.set_title("Offset fan - two-layer identical model")
 ax.legend(loc="lower right")
 plt.show()
 
@@ -495,7 +495,7 @@ plt.show()
 #
 # This extended quality test now validates equivalence at two levels:
 #
-# 1. **Single source–receiver pair**:
+# 1. **Single source-receiver pair**:
 #    analytical homogeneous formulas, homogeneous code, and identical-layered
 #    code agree for travel time, ray parameter, :math:`t^*`, geometrical
 #    spreading, transmission product, and combined factor.
@@ -508,3 +508,4 @@ plt.show()
 # Therefore, inserting an interface between layers with identical elastic
 # parameters introduces no spurious kinematic or amplitude effects in LayTracer,
 # as required by the underlying physics.
+

--- a/laytracer/api.py
+++ b/laytracer/api.py
@@ -2,14 +2,14 @@ r"""
 High-level multi-ray tracing interface.
 
 Provides :func:`trace_rays`, the main entry point for tracing all
-source–receiver pairs through a 1-D layered velocity model, with
+source-receiver pairs through a 1-D layered velocity model, with
 optional parallel execution using the ``loky`` backend.
 """
 
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Sequence
 
 import numpy as np
@@ -17,8 +17,19 @@ import pandas as pd
 import psutil
 from joblib import Parallel, delayed
 
-from .model import LayerStack, ModelArrays, build_layer_stack
-from .solver import RayResult, solve
+from .model import ModelArrays, build_layer_stack
+from .solver import solve
+
+
+TRACE_OUTPUTS = frozenset({
+    "travel_times",
+    "rays",
+    "ray_parameters",
+    "tstar",
+    "spreading",
+    "trans_product",
+})
+DEFAULT_REQUESTED = ("travel_times", "rays", "ray_parameters")
 
 
 @dataclass
@@ -50,21 +61,43 @@ class TraceResult:
     trans_product: np.ndarray | None = None
 
 
-# ═══════════════════════════════════════════════════════════════════════
-#  Worker functions
-# ═══════════════════════════════════════════════════════════════════════
+def _normalize_requested(requested: Sequence[str] | None) -> frozenset[str]:
+    """Validate and normalize the requested output names."""
+    if requested is None:
+        requested = DEFAULT_REQUESTED
+
+    normalized = frozenset(str(name) for name in requested)
+    invalid = normalized - TRACE_OUTPUTS
+    if invalid:
+        valid = ", ".join(sorted(TRACE_OUTPUTS))
+        invalid_str = ", ".join(sorted(invalid))
+        raise ValueError(f"Invalid requested outputs: {invalid_str}. Valid outputs: {valid}")
+
+    if "travel_times" not in normalized:
+        raise ValueError("requested must include 'travel_times'")
+
+    return normalized
+
 
 def _trace_batch(batch):
-    """Worker function for parallel ray computation — processes a batch.
-
-    Receives all shared data packed into *batch* so that the ``loky``
-    backend serialises it only once per worker (not once per ray).
-    Uses :class:`ModelArrays` (numpy) instead of a DataFrame for
-    lightweight pickling and avoids repeated column extraction.
-    """
-    (batch_indices, source_coords, receiver_coords, model_arrays,
-     source_phase, refl_list, refr_list,
-     compute_amplitude, transcoef_method, tol, max_iter) = batch
+    """Worker function for parallel ray computation."""
+    (
+        batch_indices,
+        source_coords,
+        receiver_coords,
+        model_arrays,
+        source_phase,
+        refl_list,
+        refr_list,
+        need_rays,
+        need_ray_parameters,
+        need_tstar,
+        need_spreading,
+        need_trans_product,
+        transcoef_method,
+        tol,
+        max_iter,
+    ) = batch
 
     results = []
     for isrc, ircv in batch_indices:
@@ -76,13 +109,41 @@ def _trace_batch(batch):
                 source_phase=source_phase,
                 refl_list=refl_list,
                 refr_list=refr_list,
-                compute_amplitude=compute_amplitude,
+                need_rays=need_rays,
+                need_ray_parameters=need_ray_parameters,
+                need_tstar=need_tstar,
+                need_spreading=need_spreading,
+                need_trans_product=need_trans_product,
                 transcoef_method=transcoef_method,
                 tol=tol,
                 max_iter=max_iter,
             )
         )
     return results
+
+
+def _project_ray_to_3d(
+    ray2d: np.ndarray | None,
+    sx: float,
+    sy: float,
+    dx: float,
+    dy: float,
+    epic: float,
+) -> np.ndarray | None:
+    """Project a 2-D ray in the epicentral plane back into 3-D."""
+    if ray2d is None:
+        return None
+
+    mpts = ray2d.shape[0]
+    ray3d = np.empty((mpts, 3))
+    if epic > 1e-10:
+        ux, uy = dx / epic, dy / epic
+    else:
+        ux, uy = 1.0, 0.0
+    ray3d[:, 0] = sx + ray2d[:, 0] * ux
+    ray3d[:, 1] = sy + ray2d[:, 0] * uy
+    ray3d[:, 2] = ray2d[:, 1]
+    return ray3d
 
 
 def _trace_one(
@@ -92,120 +153,112 @@ def _trace_one(
     source_phase: str,
     refl_list: list[tuple[float, str]],
     refr_list: list[tuple[float, str]],
-    compute_amplitude: bool,
+    need_rays: bool,
+    need_ray_parameters: bool,
+    need_tstar: bool,
+    need_spreading: bool,
+    need_trans_product: bool,
     transcoef_method: str,
     tol: float,
     max_iter: int,
-) -> tuple[float, np.ndarray, float, float | None, float | None, float | None]:
-    """Trace a single source→receiver ray.  Returns a plain tuple for
-    efficient serialisation in parallel workers."""
+) -> tuple[float, np.ndarray | None, float | None, float | None, float | None, float | None]:
+    """Trace a single source->receiver ray."""
     sx, sy, sz = float(src[0]), float(src[1]), float(src[2])
     rx, ry, rz = float(rcv[0]), float(rcv[1]), float(rcv[2])
 
-    # Epicentral distance (horizontal)
     dx, dy = rx - sx, ry - sy
     epic = np.sqrt(dx * dx + dy * dy)
 
-    # ── Fast path for direct waves (no reflections / refractions) ──
-    # Avoids itinerary-loop overhead: one build_layer_stack call,
-    # no dict wrapping, straight into the solver.
     if not refl_list and not refr_list:
         stack = build_layer_stack(ma, sz, rz)
         vel = stack.v("Vp" if source_phase == "P" else "Vs")
 
-        # Filter zero-thickness layers
         valid = stack.h > 1e-9
         if not np.any(valid):
-            ray3d = np.array([[sx, sy, sz], [rx, ry, rz]])
+            ray3d = np.array([[sx, sy, sz], [rx, ry, rz]]) if need_rays else None
 
             if epic < 1e-10:
-                # Degenerate ray: source and receiver at same point
                 return (
-                    0.0, ray3d, 0.0,
-                    0.0 if compute_amplitude else None,
-                    0.0 if compute_amplitude else None,
-                    1.0 if compute_amplitude else None,
+                    0.0,
+                    ray3d,
+                    0.0 if need_ray_parameters else None,
+                    0.0 if need_tstar else None,
+                    0.0 if need_spreading else None,
+                    1.0 if need_trans_product else None,
                 )
 
-            # Same-depth horizontal ray: straight line within one layer.
-            # All layers had zero thickness, meaning z_src ≈ z_rcv.
-            # The ray travels horizontally through the layer at that depth.
             v_hz = float(vel[0])
             tt_hz = epic / v_hz
-            p_hz = 1.0 / v_hz  # horizontal (grazing) incidence
+            p_hz = 1.0 / v_hz
 
-            if compute_amplitude:
-                q_arr = stack.qp if source_phase == "P" else stack.qs
-                tstar_hz = float(epic / (v_hz * q_arr[0])) if q_arr is not None else 0.0
-                spreading_hz = epic * v_hz  # L = r·v for homogeneous medium
-                trans_hz = 1.0              # no interface crossed
-            else:
-                tstar_hz = None
-                spreading_hz = None
-                trans_hz = None
+            q_arr = stack.qp if source_phase == "P" else stack.qs
+            tstar_hz = float(epic / (v_hz * q_arr[0])) if (need_tstar and q_arr is not None) else (0.0 if need_tstar else None)
+            spreading_hz = epic * v_hz if need_spreading else None
+            trans_hz = 1.0 if need_trans_product else None
 
-            return (tt_hz, ray3d, p_hz, tstar_hz, spreading_hz, trans_hz)
+            return (
+                tt_hz,
+                ray3d,
+                p_hz if need_ray_parameters else None,
+                tstar_hz,
+                spreading_hz,
+                trans_hz,
+            )
 
         h_f = stack.h[valid]
         v_f = vel[valid]
 
-        # Build a single segment (avoid dict — use list-of-one)
         seg = {
-            "h": h_f, "v": v_f,
-            "vp": stack.vp[valid], "vs": stack.vs[valid],
+            "h": h_f,
+            "v": v_f,
+            "vp": stack.vp[valid],
+            "vs": stack.vs[valid],
             "rho": stack.rho[valid] if stack.rho is not None else None,
             "qp": stack.qp[valid] if stack.qp is not None else None,
             "qs": stack.qs[valid] if stack.qs is not None else None,
-            "phase": source_phase, "start_z": sz, "end_z": rz,
+            "phase": source_phase,
+            "start_z": sz,
+            "end_z": rz,
         }
 
         res = solve(
-            h=h_f, v=v_f,
-            segments=[seg], interactions=[],
-            epicentral_dist=epic, z_src=sz, z_rcv=rz,
-            compute_amplitude=compute_amplitude,
+            h=h_f,
+            v=v_f,
+            segments=[seg],
+            interactions=[],
+            epicentral_dist=epic,
+            z_src=sz,
+            z_rcv=rz,
+            return_ray_path=need_rays,
+            need_ray_parameter=need_ray_parameters,
+            need_tstar=need_tstar,
+            need_spreading=need_spreading,
+            need_trans_product=need_trans_product,
             transcoef_method=transcoef_method,
-            tol=tol, max_iter=max_iter,
+            tol=tol,
+            max_iter=max_iter,
         )
 
-        ray2d = res.ray_path
-        M = ray2d.shape[0]
-        ray3d = np.empty((M, 3))
-        if epic > 1e-10:
-            ux, uy = dx / epic, dy / epic
-        else:
-            ux, uy = 1.0, 0.0
-        ray3d[:, 0] = sx + ray2d[:, 0] * ux
-        ray3d[:, 1] = sy + ray2d[:, 0] * uy
-        ray3d[:, 2] = ray2d[:, 1]
-
+        ray3d = _project_ray_to_3d(res.ray_path, sx, sy, dx, dy, epic)
         return (
-            res.travel_time, ray3d, res.ray_parameter,
-            res.tstar, res.spreading, res.trans_product,
+            res.travel_time,
+            ray3d,
+            res.ray_parameter,
+            res.tstar,
+            res.spreading,
+            res.trans_product,
         )
 
-    # ── General path: reflections and/or refractions ──
-    directional_targets = [(z, ph) for z, ph in refl_list] 
-        
-    ray_segments = [] # store (h, v, phase, direction_sign)
-    
+    ray_segments = []
     curr_z = sz
     curr_ph = source_phase
-    
-    # Full itinerary points: [Start] -> [Refl1] -> [Refl2] -> [Receiver]
+    directional_targets = [(z, ph) for z, ph in refl_list]
     itinerary_points = directional_targets + [(rz, None)]
-    
-    inter_meta = [] # metadata for amplitude
-    
+    inter_meta = []
+
     for target_z, target_ph_after_turn in itinerary_points:
-        # Direction for this major leg
-        going_down = (target_z >= curr_z)
-        
-        # Identify any refractions that occur on this path
-        # Filter refr_list for depths strictly between curr_z and target_z
-        # If going down: curr_z < z_refr < target_z
-        # If going up: target_z < z_refr < curr_z
-        
+        going_down = target_z >= curr_z
+
         relevant_refr = []
         for r_z, r_ph in refr_list:
             if going_down:
@@ -214,29 +267,19 @@ def _trace_one(
             else:
                 if target_z < r_z < curr_z:
                     relevant_refr.append((r_z, r_ph))
-        
-        # Sort refractions by proximity to curr_z
+
         if going_down:
             relevant_refr.sort(key=lambda x: x[0])
         else:
             relevant_refr.sort(key=lambda x: x[0], reverse=True)
-            
-        # Build sub-legs
+
         sub_targets = relevant_refr + [(target_z, target_ph_after_turn)]
-        
+
         for sub_z, sub_out_phase in sub_targets:
-            # Build stack for this sub-segment
-            # sub_z is the end of this sub-segment
-            
-            # Note: build_layer_stack is robust for z1 > z2 (computes thickness correctly)
             stack = build_layer_stack(ma, curr_z, sub_z)
-            
-            # Phase velocity
             vel = stack.v("Vp" if curr_ph == "P" else "Vs")
-                        
-            # Filter zero-thickness layers to avoid Vmax pollution
             valid_mask = stack.h > 1e-9
-                       
+
             if np.any(valid_mask):
                 ray_segments.append({
                     "h": stack.h[valid_mask],
@@ -248,107 +291,76 @@ def _trace_one(
                     "qs": stack.qs[valid_mask] if stack.qs is not None else None,
                     "phase": curr_ph,
                     "start_z": curr_z,
-                    "end_z": sub_z
+                    "end_z": sub_z,
                 })
-            else:                
-                pass
 
-            # Check if this sub-target is a Refraction or the Major Turn
             is_major_turn = (sub_z == target_z) and (target_ph_after_turn is not None or target_z == rz)
-            
-            # Helper to get properties of the layer BEYOND the interface
-            # If going down, "beyond" is layer starting at sub_z.
-            # If going up, "beyond" is layer ending at sub_z.
-            # We use build_layer_stack on a small interval to probe it.
-            
-            def _get_material_props(z_int, is_down_interaction):
-                # Probe a tiny segment beyond the interface
-                delta = 1.0 # 1 meter check
+
+            def _get_material_props(z_int: float, is_down_interaction: bool) -> dict[str, float]:
+                delta = 1.0
                 if is_down_interaction:
-                    # Look at [z, z+delta]
                     p_stack = build_layer_stack(ma, z_int, z_int + delta)
                 else:
-                    # Look at [z-delta, z]
                     p_stack = build_layer_stack(ma, z_int - delta, z_int)
-                
-                # Check if we are at model boundary (bottom/top)
-                # build_layer_stack handles this gracefully generally, 
-                # but let's be safe.
-                # Just return the first layer props of the stack
                 return {
                     "vp": float(p_stack.vp[0]),
                     "vs": float(p_stack.vs[0]),
-                    "rho": float(p_stack.rho[0]) if p_stack.rho is not None else 0.0
+                    "rho": float(p_stack.rho[0]) if p_stack.rho is not None else 0.0,
                 }
 
             if is_major_turn:
-                 # This is the endpoint of the major leg (Reflection or Receiver)
-                 if target_ph_after_turn is not None:
-                     # Reflection
-                     # "Beyond" side is the layer we WOULD have entered if we didn't turn.
-                     # If we are going down, beyond is Below.
-                     # If we are going up, beyond is Above (reflection from underside!).
-                     props_beyond = _get_material_props(sub_z, going_down)
-                     
-                     seg_idx = len(ray_segments) - 1
-                     if seg_idx < 0:
-                         raise ValueError(f"Cannot reflect at the starting depth {sub_z} immediately.")
+                if target_ph_after_turn is not None:
+                    props_beyond = _get_material_props(sub_z, going_down)
+                    seg_idx = len(ray_segments) - 1
+                    if seg_idx < 0:
+                        raise ValueError(f"Cannot reflect at the starting depth {sub_z} immediately.")
 
-                     inter_meta.append({
-                         "type": "reflection",
-                         "depth": sub_z,
-                         "in_phase": curr_ph,
-                         "out_phase": target_ph_after_turn,
-                         "seg_idx": seg_idx,
-                         "vp_beyond": props_beyond["vp"],
-                         "vs_beyond": props_beyond["vs"],
-                         "rho_beyond": props_beyond["rho"]
-                     })
-                     curr_ph = target_ph_after_turn
+                    inter_meta.append({
+                        "type": "reflection",
+                        "depth": sub_z,
+                        "in_phase": curr_ph,
+                        "out_phase": target_ph_after_turn,
+                        "seg_idx": seg_idx,
+                        "vp_beyond": props_beyond["vp"],
+                        "vs_beyond": props_beyond["vs"],
+                        "rho_beyond": props_beyond["rho"],
+                    })
+                    curr_ph = target_ph_after_turn
             else:
-                # Refraction/Transmission                
-                # "Beyond" side is the layer we are ABOUT to enter (which will be first layer of next segment).
-                # We can fetch it now.
                 props_beyond = _get_material_props(sub_z, going_down)
-                
                 seg_idx = len(ray_segments) - 1
                 if seg_idx < 0:
-                     raise ValueError(f"Cannot refract at the starting depth {sub_z} immediately.")
+                    raise ValueError(f"Cannot refract at the starting depth {sub_z} immediately.")
 
                 inter_meta.append({
-                     "type": "refraction",
-                     "depth": sub_z,
-                     "in_phase": curr_ph,
-                     "out_phase": sub_out_phase,
-                     "seg_idx": seg_idx,
-                     "vp_beyond": props_beyond["vp"],
-                     "vs_beyond": props_beyond["vs"],
-                     "rho_beyond": props_beyond["rho"]
+                    "type": "refraction",
+                    "depth": sub_z,
+                    "in_phase": curr_ph,
+                    "out_phase": sub_out_phase,
+                    "seg_idx": seg_idx,
+                    "vp_beyond": props_beyond["vp"],
+                    "vs_beyond": props_beyond["vs"],
+                    "rho_beyond": props_beyond["rho"],
                 })
                 curr_ph = sub_out_phase
-            
+
             curr_z = sub_z
 
-    # Flatten arrays for solver
     if len(ray_segments) == 0:
-        # Degenerate case: source and receiver share the same depth,
-        # or the path lies entirely outside the model.  Return a
-        # minimal result (zero travel time, straight-line ray, NaN
-        # amplitude quantities) so the caller can proceed.
-        ray3d = np.array([[sx, sy, sz], [rx, ry, rz]])
+        ray3d = np.array([[sx, sy, sz], [rx, ry, rz]]) if need_rays else None
+        is_same_point = epic < 1e-10 and abs(sz - rz) < 1e-10
         return (
-            0.0 if epic < 1e-10 and abs(sz - rz) < 1e-10 else np.nan,
+            0.0 if is_same_point else np.nan,
             ray3d,
-            np.nan,
-            np.nan if compute_amplitude else None,
-            np.nan if compute_amplitude else None,
-            np.nan if compute_amplitude else None,
+            np.nan if need_ray_parameters else None,
+            np.nan if need_tstar else None,
+            np.nan if need_spreading else None,
+            np.nan if need_trans_product else None,
         )
 
     all_h = np.concatenate([s["h"] for s in ray_segments])
     all_v = np.concatenate([s["v"] for s in ray_segments])
-    
-    # Solve 2-D ray    
+
     res = solve(
         h=all_h,
         v=all_v,
@@ -357,26 +369,17 @@ def _trace_one(
         epicentral_dist=epic,
         z_src=sz,
         z_rcv=rz,
-        compute_amplitude=compute_amplitude,
+        return_ray_path=need_rays,
+        need_ray_parameter=need_ray_parameters,
+        need_tstar=need_tstar,
+        need_spreading=need_spreading,
+        need_trans_product=need_trans_product,
         transcoef_method=transcoef_method,
         tol=tol,
         max_iter=max_iter,
     )
 
-    # ── Convert 2-D ray path to 3-D ──
-    ray2d = res.ray_path  # (M, 2) — [x_ray, z]
-    M = ray2d.shape[0]
-    ray3d = np.empty((M, 3))
-
-    if epic > 1e-10:
-        ux, uy = dx / epic, dy / epic
-    else:
-        ux, uy = 1.0, 0.0
-
-    ray3d[:, 0] = sx + ray2d[:, 0] * ux
-    ray3d[:, 1] = sy + ray2d[:, 0] * uy
-    ray3d[:, 2] = ray2d[:, 1]
-
+    ray3d = _project_ray_to_3d(res.ray_path, sx, sy, dx, dy, epic)
     return (
         res.travel_time,
         ray3d,
@@ -387,35 +390,20 @@ def _trace_one(
     )
 
 
-# ═══════════════════════════════════════════════════════════════════════
-#  Public API
-# ═══════════════════════════════════════════════════════════════════════
+def _unpack_results(results: list, requested: frozenset[str]) -> TraceResult:
+    """Unpack a flat list of per-ray result tuples into a TraceResult."""
 
-def _unpack_results(
-    results: list,
-    compute_amplitude: bool,
-) -> TraceResult:
-    """Unpack a flat list of per-ray result tuples into a :class:`TraceResult`."""
-    tt = np.array([r[0] for r in results])
-    rays = [r[1] for r in results]
-    p_arr = np.array([r[2] for r in results])
+    def _maybe_array(values):
+        if all(v is None for v in values):
+            return None
+        return np.array([np.nan if v is None else v for v in values], dtype=float)
 
-    tstar = None
-    spreading = None
-    trans_product = None
-
-    if compute_amplitude:
-        def _maybe_array(values):
-            if all(v is None for v in values):
-                return None
-            return np.array([np.nan if v is None else v for v in values], dtype=float)
-
-        ts = [r[3] for r in results]
-        sp = [r[4] for r in results]
-        tp = [r[5] for r in results]
-        tstar = _maybe_array(ts)
-        spreading = _maybe_array(sp)
-        trans_product = _maybe_array(tp)
+    tt = np.array([r[0] for r in results], dtype=float)
+    rays = [r[1] for r in results] if "rays" in requested else None
+    p_arr = _maybe_array([r[2] for r in results]) if "ray_parameters" in requested else None
+    tstar = _maybe_array([r[3] for r in results]) if "tstar" in requested else None
+    spreading = _maybe_array([r[4] for r in results]) if "spreading" in requested else None
+    trans_product = _maybe_array([r[5] for r in results]) if "trans_product" in requested else None
 
     return TraceResult(
         travel_times=tt,
@@ -434,7 +422,7 @@ def trace_rays(
     source_phase: str = "P",
     reflection: Sequence[tuple[float, str]] | None = None,
     refraction: Sequence[tuple[float, str]] | None = None,
-    compute_amplitude: bool = False,
+    requested: Sequence[str] | None = DEFAULT_REQUESTED,
     transcoef_method: str = "standard",
     n_jobs: int = -1,
     backend: str = "loky",
@@ -444,23 +432,15 @@ def trace_rays(
     max_iter: int = 10,
     verbose: bool = True,
 ) -> TraceResult:
-    r"""Trace rays for all source–receiver pairs.
+    r"""Trace rays for all source-receiver pairs.
 
     Every source is paired with every receiver, producing
-    ``n_src × n_rcv`` rays (each source traced to all receivers).
-
-    Parallel execution uses a **batched** dispatch strategy: rays are
-    grouped into large batches (one per worker core) so that the
-    velocity model is serialised only once per batch rather than once
-    per ray.  For very large problems the work is further split into
-    **memory-bounded chunks** whose size is automatically determined
-    from available RAM (or set explicitly via *rays_per_chunk*).
+    ``n_src x n_rcv`` rays (each source traced to all receivers).
 
     Parameters
     ----------
     sources : numpy.ndarray
-        Source coordinates, shape ``(n_src, 3)`` or ``(3,)``
-        for a single source.  Columns: ``[X, Y, Z]``.
+        Source coordinates, shape ``(n_src, 3)`` or ``(3,)``.
     receivers : numpy.ndarray
         Receiver coordinates, shape ``(n_rcv, 3)`` or ``(3,)``.
     velocity_df : pandas.DataFrame
@@ -469,23 +449,16 @@ def trace_rays(
     source_phase : str
         Initial wave phase at source: ``'P'`` or ``'S'``.
     reflection : list of (depth, phase), optional
-        List of reflection points. Each element is a tuple
-        ``(depth, out_phase)`` where ``depth`` matches a layer
-        interface in ``velocity_df`` and ``out_phase`` is the
-        phase of the reflected wave (``'P'`` or ``'S'``).
-        Example: ``[(2000.0, 'S')]`` for P-to-S reflection at 2km.
+        Reflection points as ``(depth, out_phase)`` tuples.
     refraction : list of (depth, phase), optional
-        List of specific refraction/mode-conversion points.
-        Each element is a tuple ``(depth, out_phase)``.
-        If a depth is not listed here, transmission assumes
-        preservation of the incident phase.
-    compute_amplitude : bool
-        If *True*, computes the travel time alongside the ray path, the attenuation operator
-        :math:`t^*`, relative geometrical spreading, and Zoeppritz transmission
-        products.
+        Refraction / mode-conversion points as ``(depth, out_phase)`` tuples.
+    requested : sequence of str, optional
+        Explicit set of requested outputs. Valid names are
+        ``travel_times``, ``rays``, ``ray_parameters``, ``tstar``,
+        ``spreading``, and ``trans_product``. The set must include
+        ``travel_times``.
     transcoef_method : str
-        ``'standard'`` (Zoeppritz) or ``'normalized'``
-        (Zoeppritz with Červený (2001) Eq. 5.3.10 energy-flux normalization).
+        ``'standard'`` (Zoeppritz) or ``'normalized'``.
     n_jobs : int
         Number of parallel jobs (``-1`` = all physical cores).
     backend : str
@@ -495,9 +468,6 @@ def trace_rays(
         sequentially to avoid parallel overhead.
     rays_per_chunk : int or None
         Maximum number of rays to process per memory-bounded chunk.
-        Larger values use more memory but have less overhead.  If
-        *None* (default), the chunk size is automatically determined
-        from available system memory.
     tol : float
         Newton convergence tolerance (m).
     max_iter : int
@@ -509,24 +479,25 @@ def trace_rays(
     -------
     TraceResult
     """
+    requested_set = _normalize_requested(requested)
+    need_rays = "rays" in requested_set
+    need_ray_parameters = "ray_parameters" in requested_set
+    need_tstar = "tstar" in requested_set
+    need_spreading = "spreading" in requested_set
+    need_trans_product = "trans_product" in requested_set
+
     sources = np.atleast_2d(sources)
     receivers = np.atleast_2d(receivers)
     n_src = sources.shape[0]
     n_rcv = receivers.shape[0]
     n_rays = n_src * n_rcv
 
-    # Helper: Normalize phase list to list of tuples
-    def _norm_interaction(
-        arg: Sequence[tuple[float, str]] | None
-    ) -> list[tuple[float, str]]:
-        if arg is None:
-            return []
-        return list(arg)
+    def _norm_interaction(arg: Sequence[tuple[float, str]] | None) -> list[tuple[float, str]]:
+        return [] if arg is None else list(arg)
 
     refl_list = _norm_interaction(reflection)
     refr_list = _norm_interaction(refraction)
 
-    # Validate depths against model
     model_depths = velocity_df["Depth"].values
     tol_depth = 1e-6
 
@@ -538,8 +509,9 @@ def trace_rays(
                 )
             if name == "reflection" and z < tol_depth:
                 raise ValueError(
-                    f"Reflection at the surface (z=0.0) is not currently supported for "
-                    "physical amplitude calculations. Please use a shallow internal interface instead."
+                    "Reflection at the surface (z=0.0) is not currently supported "
+                    "for physical amplitude calculations. Please use a shallow "
+                    "internal interface instead."
                 )
             if ph.upper() not in ("P", "S"):
                 raise ValueError(f"Invalid phase '{ph}' in {name}. Must be 'P' or 'S'.")
@@ -547,16 +519,12 @@ def trace_rays(
     _validate_depths(refl_list, "reflection")
     _validate_depths(refr_list, "refraction")
 
-    # Check for conflicts (same depth in both lists)
     refl_z = {z for z, _ in refl_list}
     refr_z = {z for z, _ in refr_list}
     common = refl_z.intersection(refr_z)
     if common:
-        raise ValueError(
-            f"Cannot strictly reflect and refract at the same depth(s): {common}"
-        )
+        raise ValueError(f"Cannot strictly reflect and refract at the same depth(s): {common}")
 
-    # ── Pre-extract arrays from DataFrame once (lightweight pickle) ──
     ma = ModelArrays.from_dataframe(velocity_df)
 
     common_kw = dict(
@@ -564,22 +532,24 @@ def trace_rays(
         source_phase=source_phase,
         refl_list=refl_list,
         refr_list=refr_list,
-        compute_amplitude=compute_amplitude,
+        need_rays=need_rays,
+        need_ray_parameters=need_ray_parameters,
+        need_tstar=need_tstar,
+        need_spreading=need_spreading,
+        need_trans_product=need_trans_product,
         transcoef_method=transcoef_method,
         tol=tol,
         max_iter=max_iter,
     )
 
-    # ── Sequential path ──
     if n_rays <= sequential_limit or n_jobs == 1:
         results = [
             _trace_one(src=sources[i], rcv=receivers[j], **common_kw)
             for i in range(n_src)
             for j in range(n_rcv)
         ]
-        return _unpack_results(results, compute_amplitude)
+        return _unpack_results(results, requested_set)
 
-    # ── Determine worker count ──
     if n_jobs == -1:
         n_workers = min(psutil.cpu_count(logical=False) or 4, n_rays)
     elif n_jobs < 0:
@@ -587,15 +557,19 @@ def trace_rays(
     else:
         n_workers = n_jobs
 
-    # ── Auto-determine rays_per_chunk from available memory ──
     if rays_per_chunk is None:
         available_mem = psutil.virtual_memory().available
-        # Estimate memory per ray (indices + result tuple + ray path array)
-        bytes_per_ray = 64  # base: index tuple + travel-time scalar
-        bytes_per_ray += 200  # ray path (typical ~8 points × 3 coords × 8 bytes)
-        if compute_amplitude:
-            bytes_per_ray += 200  # tstar, spreading, trans_product extras
-        # Use 50% of available memory, divided by worker count
+        bytes_per_ray = 64
+        if need_rays:
+            bytes_per_ray += 200
+        if need_ray_parameters:
+            bytes_per_ray += 8
+        if need_tstar:
+            bytes_per_ray += 8
+        if need_spreading:
+            bytes_per_ray += 8
+        if need_trans_product:
+            bytes_per_ray += 8
         usable_mem = available_mem * 0.5 / n_workers
         rays_per_chunk = max(100_000, int(usable_mem / bytes_per_ray))
         if verbose:
@@ -604,17 +578,11 @@ def trace_rays(
                 f"(based on {available_mem / 1e9:.1f} GB available RAM)"
             )
 
-    # ── Helper: build batches for a set of index pairs ──
     def _make_batches(index_pairs, src_arr, rcv_arr):
-        """Split *index_pairs* into ~n_workers equal batches.
-
-        Each batch carries the shared source/receiver arrays and
-        :class:`ModelArrays` (numpy-only, fast to pickle) rather
-        than a DataFrame."""
         batch_size = max(1, len(index_pairs) // n_workers)
         batches = []
         for i in range(0, len(index_pairs), batch_size):
-            chunk = index_pairs[i : i + batch_size]
+            chunk = index_pairs[i:i + batch_size]
             batches.append((
                 chunk,
                 src_arr,
@@ -623,32 +591,33 @@ def trace_rays(
                 source_phase,
                 refl_list,
                 refr_list,
-                compute_amplitude,
+                need_rays,
+                need_ray_parameters,
+                need_tstar,
+                need_spreading,
+                need_trans_product,
                 transcoef_method,
                 tol,
                 max_iter,
             ))
         return batches
 
-    # ── Chunked processing for very large problems ──
     if n_rays > rays_per_chunk:
-        # Chunk along the receiver axis to keep memory bounded
         rcv_per_chunk = max(1, rays_per_chunk // n_src)
         n_chunks = (n_rcv + rcv_per_chunk - 1) // rcv_per_chunk
 
         if verbose:
             print(
-                f"Total rays: {n_rays:,} — processing in {n_chunks} chunks "
+                f"Total rays: {n_rays:,} - processing in {n_chunks} chunks "
                 f"({rcv_per_chunk:,} receivers per chunk)..."
             )
 
-        # Pre-allocate flat result arrays
         tt_all = np.empty(n_rays, dtype=np.float64)
-        p_all = np.empty(n_rays, dtype=np.float64)
-        rays_all: list[np.ndarray | None] = [None] * n_rays
-        tstar_all = np.full(n_rays, np.nan, dtype=np.float64) if compute_amplitude else None
-        spread_all = np.full(n_rays, np.nan, dtype=np.float64) if compute_amplitude else None
-        trans_all = np.full(n_rays, np.nan, dtype=np.float64) if compute_amplitude else None
+        rays_all: list[np.ndarray | None] | None = [None] * n_rays if need_rays else None
+        p_all = np.full(n_rays, np.nan, dtype=np.float64) if need_ray_parameters else None
+        tstar_all = np.full(n_rays, np.nan, dtype=np.float64) if need_tstar else None
+        spread_all = np.full(n_rays, np.nan, dtype=np.float64) if need_spreading else None
+        trans_all = np.full(n_rays, np.nan, dtype=np.float64) if need_trans_product else None
 
         chunk_times: list[float] = []
         total_start = time.time()
@@ -661,20 +630,13 @@ def trace_rays(
             chunk_rcv = receivers[rcv_start:rcv_end]
             chunk_nrcv = rcv_end - rcv_start
 
-            # Build index pairs for this chunk (indices into sources / chunk_rcv)
-            chunk_pairs = [
-                (i, j)
-                for i in range(n_src)
-                for j in range(chunk_nrcv)
-            ]
-
+            chunk_pairs = [(i, j) for i in range(n_src) for j in range(chunk_nrcv)]
             batches = _make_batches(chunk_pairs, sources, chunk_rcv)
 
             batch_results = Parallel(
                 n_jobs=n_workers, backend=backend, pre_dispatch="all"
             )(delayed(_trace_batch)(b) for b in batches)
 
-            # Flatten and store at correct global indices
             flat_idx = 0
             for batch_result in batch_results:
                 for res in batch_result:
@@ -684,18 +646,18 @@ def trace_rays(
                     global_idx = local_isrc * n_rcv + global_ircv
 
                     tt_all[global_idx] = res[0]
-                    rays_all[global_idx] = res[1]
-                    p_all[global_idx] = res[2]
-                    if compute_amplitude:
-                        if tstar_all is not None and res[3] is not None:
-                            tstar_all[global_idx] = res[3]
-                        if spread_all is not None and res[4] is not None:
-                            spread_all[global_idx] = res[4]
-                        if trans_all is not None and res[5] is not None:
-                            trans_all[global_idx] = res[5]
+                    if rays_all is not None:
+                        rays_all[global_idx] = res[1]
+                    if p_all is not None and res[2] is not None:
+                        p_all[global_idx] = res[2]
+                    if tstar_all is not None and res[3] is not None:
+                        tstar_all[global_idx] = res[3]
+                    if spread_all is not None and res[4] is not None:
+                        spread_all[global_idx] = res[4]
+                    if trans_all is not None and res[5] is not None:
+                        trans_all[global_idx] = res[5]
                     flat_idx += 1
 
-            # Timing / progress
             chunk_elapsed = time.time() - chunk_start
             chunk_times.append(chunk_elapsed)
             if verbose:
@@ -709,10 +671,9 @@ def trace_rays(
                     eta = f"{remaining:.0f}s"
                 print(
                     f"  Chunk {chunk_idx + 1}/{n_chunks} done "
-                    f"({chunk_elapsed:.1f}s) — ETA: {eta}"
+                    f"({chunk_elapsed:.1f}s) - ETA: {eta}"
                 )
 
-            # Free intermediate memory
             del chunk_pairs, batches, batch_results
 
         if verbose:
@@ -734,22 +695,15 @@ def trace_rays(
             trans_product=trans_all,
         )
 
-    # ── Standard batched parallel path (fits in one chunk) ──
-    all_pairs = [
-        (i, j)
-        for i in range(n_src)
-        for j in range(n_rcv)
-    ]
-
+    all_pairs = [(i, j) for i in range(n_src) for j in range(n_rcv)]
     batches = _make_batches(all_pairs, sources, receivers)
 
     batch_results = Parallel(
         n_jobs=n_workers, backend=backend, pre_dispatch="all"
     )(delayed(_trace_batch)(b) for b in batches)
 
-    # Flatten batches into a single result list
     results: list = []
     for br in batch_results:
         results.extend(br)
 
-    return _unpack_results(results, compute_amplitude)
+    return _unpack_results(results, requested_set)

--- a/laytracer/api.py
+++ b/laytracer/api.py
@@ -123,7 +123,7 @@ def _trace_one(
                 return (
                     0.0, ray3d, 0.0,
                     0.0 if compute_amplitude else None,
-                    None if compute_amplitude else None,
+                    0.0 if compute_amplitude else None,
                     1.0 if compute_amplitude else None,
                 )
 
@@ -405,12 +405,17 @@ def _unpack_results(
     trans_product = None
 
     if compute_amplitude:
+        def _maybe_array(values):
+            if all(v is None for v in values):
+                return None
+            return np.array([np.nan if v is None else v for v in values], dtype=float)
+
         ts = [r[3] for r in results]
         sp = [r[4] for r in results]
         tp = [r[5] for r in results]
-        tstar = np.array(ts, dtype=float) if ts[0] is not None else None
-        spreading = np.array(sp, dtype=float) if sp[0] is not None else None
-        trans_product = np.array(tp, dtype=float) if tp[0] is not None else None
+        tstar = _maybe_array(ts)
+        spreading = _maybe_array(sp)
+        trans_product = _maybe_array(tp)
 
     return TraceResult(
         travel_times=tt,
@@ -641,9 +646,9 @@ def trace_rays(
         tt_all = np.empty(n_rays, dtype=np.float64)
         p_all = np.empty(n_rays, dtype=np.float64)
         rays_all: list[np.ndarray | None] = [None] * n_rays
-        tstar_all = np.empty(n_rays, dtype=np.float64) if compute_amplitude else None
-        spread_all = np.empty(n_rays, dtype=np.float64) if compute_amplitude else None
-        trans_all = np.empty(n_rays, dtype=np.float64) if compute_amplitude else None
+        tstar_all = np.full(n_rays, np.nan, dtype=np.float64) if compute_amplitude else None
+        spread_all = np.full(n_rays, np.nan, dtype=np.float64) if compute_amplitude else None
+        trans_all = np.full(n_rays, np.nan, dtype=np.float64) if compute_amplitude else None
 
         chunk_times: list[float] = []
         total_start = time.time()

--- a/laytracer/solver.py
+++ b/laytracer/solver.py
@@ -326,11 +326,15 @@ def solve(
 
         tstar = None
         trans_prod_val = None
+        spreading_val = None
         
         if compute_amplitude:
-            # sum dt / Q over all layers
+            # Use the p -> 0 limit of the direct-wave spreading expression.
+            # For a layered vertical ray this reduces to sum(h_k * v_k), i.e.
+            # Vrms^2 * travel time along the traversed path.
             tstar_val = 0.0
             trans_prod_val = 1.0
+            spreading_val = float(np.sum(h * v))
             
             # Since p=0 for vertical ray
             p_vert = 0.0
@@ -378,7 +382,7 @@ def solve(
             ray_path=pts,
             ray_parameter=0.0,
             tstar=tstar,
-            spreading=None,  # undefined for vertical ray (p=0)
+            spreading=spreading_val,
             trans_product=trans_prod_val,
         )
 

--- a/laytracer/solver.py
+++ b/laytracer/solver.py
@@ -18,6 +18,32 @@ import scipy.optimize as opt
 
 from .model import LayerStack
 
+SOLVE_OUTPUTS = frozenset({
+    "travel_times",
+    "rays",
+    "ray_parameters",
+    "tstar",
+    "spreading",
+    "trans_product",
+})
+
+
+def _normalize_requested(requested):
+    if requested is None:
+        return None
+
+    normalized = frozenset(str(name) for name in requested)
+    invalid = normalized - SOLVE_OUTPUTS
+    if invalid:
+        valid = ", ".join(sorted(SOLVE_OUTPUTS))
+        invalid_str = ", ".join(sorted(invalid))
+        raise ValueError(f"Invalid requested outputs: {invalid_str}. Valid outputs: {valid}")
+
+    if "travel_times" not in normalized:
+        raise ValueError("requested must include 'travel_times'")
+
+    return normalized
+
 
 # ═══════════════════════════════════════════════════════════════════════
 #  Offset equation and derivatives
@@ -237,10 +263,10 @@ class RayResult:
     ----------
     travel_time : float
         Total travel time (s).
-    ray_path : numpy.ndarray
+    ray_path : numpy.ndarray or None
         Ray coordinates in the 2-D ray plane, shape ``(M, 2)``
-        with columns ``[x, z]``.
-    ray_parameter : float
+        with columns ``[x, z]``.  *None* if not requested.
+    ray_parameter : float or None
         Horizontal slowness *p* (s/m).
     tstar : float or None
         Attenuation operator :math:`t^*` (s), if requested.
@@ -252,8 +278,8 @@ class RayResult:
     """
 
     travel_time: float
-    ray_path: np.ndarray
-    ray_parameter: float
+    ray_path: np.ndarray | None
+    ray_parameter: float | None
     tstar: float | None = None
     spreading: float | None = None
     trans_product: float | None = None
@@ -271,7 +297,12 @@ def solve(
     epicentral_dist: float,
     z_src: float,
     z_rcv: float,
-    compute_amplitude: bool = False,
+    requested=None,
+    return_ray_path: bool = True,
+    need_ray_parameter: bool = True,
+    need_tstar: bool = False,
+    need_spreading: bool = False,
+    need_trans_product: bool = False,
     transcoef_method: str = "standard",
     tol: float = 1e-4,
     max_iter: int = 10,
@@ -292,49 +323,38 @@ def solve(
         Dict keys: 'type', 'depth', 'in_phase', 'out_phase', 'seg_idx'.
     interactions are assumed to occur at the END of the defined segment.
     """
-    N = len(h)    
+    requested = _normalize_requested(requested)
+    if requested is not None:
+        return_ray_path = "rays" in requested
+        need_ray_parameter = "ray_parameters" in requested
+        need_tstar = "tstar" in requested
+        need_spreading = "spreading" in requested
+        need_trans_product = "trans_product" in requested
+
+    N = len(h)
 
     # ── Vertical / zero-offset ray ──
     if epicentral_dist < 1e-10:
         tt = float(np.sum(h / v))
-        # Build vertical ray path
-        # Reconstruct path based on segments
-        # This is a bit complex for vertical rays with bounces, but solvable.
-        pts_list = []
-        curr_x = 0.0
-        # Start point
-        pts_list.append([0.0, z_src])
-        
-        for seg in segments:
-            seg_h = seg["h"]
-            n_seg = len(seg_h)
-            z_start = seg["start_z"]
-            z_end = seg["end_z"]
-            going_down = z_end >= z_start
-            
-            # For geometric path reconstruction
-            # We just need to know the sequence of depths
-            # Vertical ray: x is constant 0
-            
-            # Simple Z reconstruction:
-            # We assume segments are continuous.
-            if n_seg > 0:
-                # Add end point of this segment
-                pts_list.append([0.0, z_end])
-        
-        pts = np.array(pts_list)
+        pts = None
+        if return_ray_path:
+            pts_list = [[0.0, z_src]]
+            for seg in segments:
+                if len(seg["h"]) > 0:
+                    pts_list.append([0.0, seg["end_z"]])
+            pts = np.array(pts_list)
 
         tstar = None
         trans_prod_val = None
         spreading_val = None
         
-        if compute_amplitude:
+        if need_tstar or need_spreading or need_trans_product:
             # Use the p -> 0 limit of the direct-wave spreading expression.
             # For a layered vertical ray this reduces to sum(h_k * v_k), i.e.
             # Vrms^2 * travel time along the traversed path.
             tstar_val = 0.0
-            trans_prod_val = 1.0
-            spreading_val = float(np.sum(h * v))
+            trans_prod_val = 1.0 if need_trans_product else None
+            spreading_val = float(np.sum(h * v)) if need_spreading else None
             
             # Since p=0 for vertical ray
             p_vert = 0.0
@@ -343,44 +363,38 @@ def solve(
                 ph = seg["phase"]
                 q_key = "qp" if ph == "P" else "qs"
                 # Handle missing Q
-                if seg[q_key] is not None:
+                if need_tstar and seg[q_key] is not None:
                      tstar_val += np.sum(seg["h"] / seg["v"] / seg[q_key])
-                     
-                # Transmission within segment
-                n_lay = len(seg["h"])
-                # Direction doesn't change physics of transmission coeff formula for p=0 much
-                # but we need correct k_curr, k_next.
-                z_start = seg["start_z"]
-                z_end = seg["end_z"]
-                going_down = z_end >= z_start
-                
-                # Intra-segment transmission
-                range_k = range(n_lay) if going_down else range(n_lay - 1, -1, -1)
-                
-                for k in range_k:
-                    # Check for next layer
-                    has_next_layer = (k < n_lay - 1) if going_down else (k > 0)
-                    if has_next_layer:
-                        k_next = (k + 1) if going_down else (k - 1)
-                        if seg["rho"] is not None:
-                            trans_prod_val *= _calc_intra_transmission(
-                                p_vert, k, k_next, seg, transcoef_method
-                            )
-                            
-                # Explicit interaction at end of segment
-                for inter in interactions:
-                    if inter["seg_idx"] == seg_i:
-                        coeff = _calc_interaction_coeff(
-                            p_vert, inter, segments, seg_i, transcoef_method
-                        )
-                        trans_prod_val *= coeff
 
-            tstar = float(tstar_val)
+                if need_trans_product:
+                    n_lay = len(seg["h"])
+                    z_start = seg["start_z"]
+                    z_end = seg["end_z"]
+                    going_down = z_end >= z_start
+                    range_k = range(n_lay) if going_down else range(n_lay - 1, -1, -1)
+
+                    for k in range_k:
+                        has_next_layer = (k < n_lay - 1) if going_down else (k > 0)
+                        if has_next_layer:
+                            k_next = (k + 1) if going_down else (k - 1)
+                            if seg["rho"] is not None:
+                                trans_prod_val *= _calc_intra_transmission(
+                                    p_vert, k, k_next, seg, transcoef_method
+                                )
+
+                    for inter in interactions:
+                        if inter["seg_idx"] == seg_i:
+                            coeff = _calc_interaction_coeff(
+                                p_vert, inter, segments, seg_i, transcoef_method
+                            )
+                            trans_prod_val *= coeff
+
+            tstar = float(tstar_val) if need_tstar else None
 
         return RayResult(
             travel_time=tt,
             ray_path=pts,
-            ray_parameter=0.0,
+            ray_parameter=0.0 if need_ray_parameter else None,
             tstar=tstar,
             spreading=spreading_val,
             trans_product=trans_prod_val,
@@ -394,22 +408,29 @@ def solve(
         dist = np.sqrt(epicentral_dist ** 2 + dz ** 2)
         tt = dist / v[0]
         p = epicentral_dist / (v[0] * dist)
-        pts = np.array([[0.0, z_src], [epicentral_dist, z_rcv]])
+        pts = np.array([[0.0, z_src], [epicentral_dist, z_rcv]]) if return_ray_path else None
 
         tstar = None
         trans_prod = None
         spreading = None
-        if compute_amplitude:
-             # Need Q from the single segment
+        if need_tstar or need_spreading or need_trans_product:
              seg = segments[0]
              q_key = "qp" if seg["phase"] == "P" else "qs"
-             if seg[q_key] is not None:
+             if need_tstar and seg[q_key] is not None:
                  tstar = tt / seg[q_key][0]
-             # Relative geometrical spreading in homogeneous medium is distance * velocity (formally at receiver)
-             spreading = dist * v[-1]
-             trans_prod = 1.0
+             if need_spreading:
+                 spreading = dist * v[-1]
+             if need_trans_product:
+                 trans_prod = 1.0
 
-        return RayResult(tt, pts, p, tstar, spreading, trans_prod)
+        return RayResult(
+            tt,
+            pts,
+            p if need_ray_parameter else None,
+            tstar,
+            spreading,
+            trans_prod,
+        )
 
     # ── General multi-layer case ──
     vmax = float(np.max(v))
@@ -440,18 +461,15 @@ def solve(
     # ── Propagate ray ──
     tt = 0.0
     tstar_val = 0.0
-    trans_prod_val = 1.0
-    
-    # Path reconstruction
-    pts_list = [[0.0, z_src]]
+    trans_prod_val = 1.0 if need_trans_product else None
+
+    pts_list = [[0.0, z_src]] if return_ray_path else None
     x_cum = 0.0
     z_cum = z_src
     
     # We iterate over SEGMENTS to reconstruct the path logic
     # The solver treated 'h' and 'v' as one giant array.
     # We need to map back to the segments structure for Q and coordinates.
-    
-    global_k = 0 # index into the flattened velocity/thickness arrays
     
     for seg_i, seg in enumerate(segments):
         n_lay = len(seg["h"])
@@ -487,16 +505,17 @@ def solve(
             dz = val_h if going_down else -val_h
             z_cum += dz
             
-            pts_list.append([x_cum, z_cum])
-            
-            if compute_amplitude and seg_q is not None:
+            if return_ray_path:
+                pts_list.append([x_cum, z_cum])
+
+            if need_tstar and seg_q is not None:
                 tstar_val += dt_k / seg_q[k]
                 
             # Transmission logic within the segment
             # This handles standard transmission across interfaces INSIDE the monotonic stack.
             # If we are traversing indices k -> k+1 (Down) or k -> k-1 (Up):
             # Interface is between them.
-            if compute_amplitude:
+            if need_trans_product:
                 # Identification of the interface
                 has_next_layer = (k < n_lay - 1) if going_down else (k > 0)
                 
@@ -515,7 +534,7 @@ def solve(
 
         # ── Explicit Interaction at End of Segment ──
         # Check if there is an interaction defined for this segment index
-        if compute_amplitude:
+        if need_trans_product:
             # Find interaction where seg_idx == seg_i
             # (There should be at most one per segment end)
             for inter in interactions:
@@ -523,11 +542,11 @@ def solve(
                     coeff = _calc_interaction_coeff(p, inter, segments, seg_i, transcoef_method)
                     trans_prod_val *= coeff
 
-    pts = np.array(pts_list)
+    pts = np.array(pts_list) if return_ray_path else None
 
     # ── Geometrical spreading ──
     spreading_val = None
-    if compute_amplitude:
+    if need_spreading:
         dXdq = offset_dq(q, h, lmd)
         pv = p * vmax
         denom_dp = (1.0 - pv * pv)
@@ -552,10 +571,10 @@ def solve(
     return RayResult(
         travel_time=tt,
         ray_path=pts,
-        ray_parameter=p,
-        tstar=tstar_val if compute_amplitude else None,
+        ray_parameter=p if need_ray_parameter else None,
+        tstar=tstar_val if need_tstar else None,
         spreading=spreading_val,
-        trans_product=trans_prod_val if compute_amplitude else None,
+        trans_product=trans_prod_val,
     )
 
 def _calc_interaction_coeff(p, inter, segments, seg_idx, method):

--- a/pytests/test_amplitude.py
+++ b/pytests/test_amplitude.py
@@ -18,9 +18,9 @@ def _simple_model():
         "Qs":    [100.0,  200.0,  300.0],
     })
 
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 #  Theory Verification
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 
 class TestTheoryVerification:
     """Rigorous quantitative verification of mathematical theory for t* and spreading."""
@@ -51,7 +51,7 @@ class TestTheoryVerification:
         # Run solver exactly to the target X
         res = laytracer.solve(
             h, v, segments, [], epicentral_dist=X_target, z_src=0.0, z_rcv=3000.0,
-            compute_amplitude=True, tol=1e-10
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}, tol=1e-10
         )
         
         # Verify it matched the expected parameter and the theoretical tstar formula exactly
@@ -104,7 +104,7 @@ class TestTheoryVerification:
         # Run solver exactly to the target X
         res = laytracer.solve(
             h, v, segments, [], epicentral_dist=X_target, z_src=0.0, z_rcv=3000.0,
-            compute_amplitude=True, tol=1e-10
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}, tol=1e-10
         )
         
         assert res.ray_parameter == pytest.approx(p, rel=1e-5)
@@ -127,7 +127,7 @@ class TestTheoryVerification:
         
         res = laytracer.solve(
             h, v, segments, [], X_target, 0.0, 3000.0,
-            compute_amplitude=False, tol=1e-10
+            requested={"travel_times", "rays", "ray_parameters"}, tol=1e-10
         )
         
         # Recompute offset from returned p using internal q logic
@@ -155,9 +155,9 @@ class TestTheoryVerification:
         assert offset_dq2(q, h, lmd) == pytest.approx(d2_fd, rel=1e-2)
 
 
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 #  Transmission coefficients
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 
 class TestTransmission:
     def test_normal_same_medium(self):
@@ -213,9 +213,9 @@ class TestTransmission:
         assert abs(RTp["Tsp"]) == pytest.approx(0.0, abs=1e-8)
 
 
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 #  t* computation
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 
 
 class TestTstar:
@@ -236,7 +236,7 @@ class TestTstar:
         
         res = laytracer.solve(
             h, v, segments, [], epicentral_dist=0.0, z_src=0.0, z_rcv=3000.0,
-            compute_amplitude=True,
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         )
         expected = 3000.0 / 5000.0 / 500.0  # h / v / Q = tt / Q
         assert res.tstar == pytest.approx(expected, rel=1e-4)
@@ -264,14 +264,14 @@ class TestTstar:
         
         res = laytracer.solve(
             h, v, segments, [], epicentral_dist=5000.0, z_src=100.0, z_rcv=2500.0,
-            compute_amplitude=True,
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         )
         assert res.tstar == pytest.approx(res.travel_time / Q, rel=1e-4)
 
 
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 #  Geometrical spreading
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 
 class TestSpreading:
     def test_spreading_homogeneous(self):
@@ -294,7 +294,7 @@ class TestSpreading:
         z_src, z_rcv = 0.0, 3000.0
         res = laytracer.solve(
             h, v, segments, [], epicentral_dist=X, z_src=z_src, z_rcv=z_rcv,
-            compute_amplitude=True,
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         )
         dist = np.sqrt(X**2 + (z_rcv - z_src)**2)
         # Definition: relative spreading = distance * velocity (formally at receiver)
@@ -316,7 +316,7 @@ class TestSpreading:
 
         res = laytracer.solve(
             h, v, segments, [], X, z_src, z_rcv, 
-            compute_amplitude=True, tol=1e-10
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}, tol=1e-10
         )
 
         dist = np.sqrt(X**2 + (z_rcv - z_src)**2)
@@ -338,14 +338,14 @@ class TestSpreading:
         
         res = laytracer.solve(
             h, v, segments, [], epicentral_dist=5000.0, z_src=500.0, z_rcv=2500.0,
-            compute_amplitude=True,
+            requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         )
         assert res.spreading is not None
         assert res.spreading > 0
 
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 #  Brewster-angle detection
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 
 def _ammon_model_rt(n=1000):
     """Compute RT coefficients for Ammon's crust/mantle test case.
@@ -386,7 +386,7 @@ class TestBrewsterAngles:
         assert result == {}
 
     def test_p_incident_rps_brewster(self):
-        """For Ammon model, |Rps| has a Brewster angle near 37.9°."""
+        """For Ammon model, |Rps| has a Brewster angle near 37.9??."""
         RT_P, angle_P, _, _ = _ammon_model_rt()
         result = laytracer.find_brewster_angles(RT_P, angle_P, keys=["Rps"])
         assert "Rps" in result
@@ -394,7 +394,7 @@ class TestBrewsterAngles:
         assert result["Rps"][0] == pytest.approx(37.9, abs=0.5)
 
     def test_sv_incident_rss_brewster(self):
-        """For Ammon model, |Rss| has a Brewster angle near 19.8°."""
+        """For Ammon model, |Rss| has a Brewster angle near 19.8??."""
         _, _, RT_SV, angle_SV = _ammon_model_rt()
         result = laytracer.find_brewster_angles(RT_SV, angle_SV, keys=["Rss"])
         assert "Rss" in result
@@ -402,7 +402,7 @@ class TestBrewsterAngles:
         assert result["Rss"][0] == pytest.approx(19.8, abs=0.5)
 
     def test_sv_incident_rsp_two_brewsters(self):
-        """For Ammon model, |Rsp| has two Brewster angles near 21° and 40°."""
+        """For Ammon model, |Rsp| has two Brewster angles near 21?? and 40??."""
         _, _, RT_SV, angle_SV = _ammon_model_rt()
         result = laytracer.find_brewster_angles(RT_SV, angle_SV, keys=["Rsp"])
         assert "Rsp" in result
@@ -431,3 +431,4 @@ class TestBrewsterAngles:
         n_strict = len(strict.get("Rps", []))
         n_loose = len(loose.get("Rps", []))
         assert n_loose >= n_strict
+

--- a/pytests/test_api.py
+++ b/pytests/test_api.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import laytracer
+from laytracer.api import _unpack_results
 
 
 def _simple_model():
@@ -118,6 +119,30 @@ class TestTraceRays:
         assert result.tstar is None
         assert result.spreading is None
 
+    def test_zero_offset_vertical_ray_has_finite_amplitudes(self):
+        """Zero-offset direct rays through multiple layers must keep finite amplitudes."""
+        df = _simple_model()
+        src = np.array([0.0, 0.0, 500.0])
+        rcv = np.array([0.0, 0.0, 1500.0])
+        result = laytracer.trace_rays(
+            src, rcv, df, compute_amplitude=True, n_jobs=1
+        )
+
+        expected_tt = 500.0 / 3000.0 + 500.0 / 4500.0
+        expected_tstar = 500.0 / (3000.0 * 200.0) + 500.0 / (4500.0 * 400.0)
+        expected_spreading = 500.0 * 3000.0 + 500.0 * 4500.0
+        expected_trans = abs(
+            laytracer.transmission_normal(3000.0, 2200.0, 4500.0, 2500.0)
+        )
+
+        assert result.travel_times[0] == pytest.approx(expected_tt, rel=1e-6)
+        assert result.tstar[0] == pytest.approx(expected_tstar, rel=1e-6)
+        assert result.spreading[0] == pytest.approx(expected_spreading, rel=1e-6)
+        assert result.trans_product[0] == pytest.approx(expected_trans, rel=1e-6)
+        assert np.isfinite(result.tstar[0])
+        assert np.isfinite(result.spreading[0])
+        assert np.isfinite(result.trans_product[0])
+
     def test_same_point_degenerate(self):
         """Source and receiver at the exact same point."""
         df = _simple_model()
@@ -127,6 +152,10 @@ class TestTraceRays:
             src, rcv, df, compute_amplitude=True
         )
         assert result.travel_times[0] == pytest.approx(0.0)
+        assert result.tstar[0] == pytest.approx(0.0)
+        assert result.spreading[0] == pytest.approx(0.0)
+        assert result.trans_product[0] == pytest.approx(1.0)
+        assert np.isfinite(result.spreading[0])
 
     def test_3d_ray_path_coords(self):
         """3-D ray path starts at source and ends at receiver."""
@@ -139,3 +168,20 @@ class TestTraceRays:
         np.testing.assert_allclose(ray[0], src, atol=1.0)
         # End point z
         assert ray[-1, 2] == pytest.approx(rcv[2], abs=1.0)
+
+
+def test_unpack_results_handles_mixed_none_amplitudes():
+    """Mixed finite/None amplitude values should unpack to arrays with NaNs."""
+    results = [
+        (1.0, np.array([[0.0, 0.0, 0.0]]), 0.1, 0.2, None, 1.0),
+        (2.0, np.array([[1.0, 0.0, 0.0]]), 0.2, 0.3, 4.5, None),
+    ]
+
+    unpacked = _unpack_results(results, compute_amplitude=True)
+
+    np.testing.assert_allclose(unpacked.travel_times, [1.0, 2.0])
+    np.testing.assert_allclose(unpacked.tstar, [0.2, 0.3])
+    assert np.isnan(unpacked.spreading[0])
+    assert unpacked.spreading[1] == pytest.approx(4.5)
+    assert unpacked.trans_product[0] == pytest.approx(1.0)
+    assert np.isnan(unpacked.trans_product[1])

--- a/pytests/test_api.py
+++ b/pytests/test_api.py
@@ -21,7 +21,7 @@ def _simple_model():
 
 class TestTraceRays:
     def test_single_pair(self):
-        """One source → one receiver."""
+        """One source ??? one receiver."""
         df = _simple_model()
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([5000.0, 0.0, 2500.0])
@@ -33,7 +33,7 @@ class TestTraceRays:
         assert result.rays[0].shape[1] == 3
 
     def test_multiple_receivers(self):
-        """One source → multiple receivers."""
+        """One source ??? multiple receivers."""
         df = _simple_model()
         src = np.array([0.0, 0.0, 500.0])
         rcvs = np.array([
@@ -46,12 +46,12 @@ class TestTraceRays:
         assert len(result.rays) == 3
 
     def test_multiple_sources(self):
-        """Multiple sources × multiple receivers."""
+        """Multiple sources ?? multiple receivers."""
         df = _simple_model()
         srcs = np.array([[0.0, 0.0, 2500.0], [1000.0, 0.0, 1500.0]])
         rcvs = np.array([[3000.0, 0.0, 0.0], [6000.0, 0.0, 0.0]])
         result = laytracer.trace_rays(srcs, rcvs, df)
-        # 2 sources × 2 receivers = 4 rays
+        # 2 sources ?? 2 receivers = 4 rays
         assert result.travel_times.shape == (4,)
         assert len(result.rays) == 4
 
@@ -65,7 +65,12 @@ class TestTraceRays:
             [7000.0, -2000.0, 0.0],
         ])
         r_seq = laytracer.trace_rays(src, rcvs, df, n_jobs=1)
-        r_par = laytracer.trace_rays(src, rcvs, df, n_jobs=2, sequential_limit=0)
+        try:
+            r_par = laytracer.trace_rays(
+                src, rcvs, df, n_jobs=2, backend="threading", sequential_limit=0
+            )
+        except PermissionError:
+            pytest.skip("Parallel worker creation is blocked in this environment")
 
         np.testing.assert_allclose(
             r_seq.travel_times, r_par.travel_times, rtol=1e-10
@@ -77,7 +82,7 @@ class TestTraceRays:
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([5000.0, 0.0, 2500.0])
         result = laytracer.trace_rays(
-            src, rcv, df, compute_amplitude=True
+            src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}
         )
         assert result.tstar is not None
         assert result.spreading is not None
@@ -90,7 +95,7 @@ class TestTraceRays:
         src = np.array([0.0, 0.0, 0.0])
         rcv = np.array([5000.0, 0.0, 0.0])
         result = laytracer.trace_rays(
-            src, rcv, df, compute_amplitude=True
+            src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}
         )
         # Travel time must be finite and positive
         assert np.isfinite(result.travel_times[0])
@@ -104,7 +109,7 @@ class TestTraceRays:
         assert np.isfinite(result.trans_product[0])
         # Spreading = epic * v for homogeneous medium
         assert result.spreading[0] == pytest.approx(5000.0 * 3000.0, rel=1e-6)
-        # No interface crossed → T = 1
+        # No interface crossed ??? T = 1
         assert result.trans_product[0] == pytest.approx(1.0)
 
     def test_same_depth_no_amplitude(self):
@@ -112,7 +117,7 @@ class TestTraceRays:
         df = _simple_model()
         src = np.array([0.0, 0.0, 1500.0])
         rcv = np.array([3000.0, 4000.0, 1500.0])
-        result = laytracer.trace_rays(src, rcv, df, compute_amplitude=False)
+        result = laytracer.trace_rays(src, rcv, df, requested={"travel_times", "rays", "ray_parameters"})
         epic = 5000.0
         expected_tt = epic / 4500.0  # layer 1 velocity
         assert result.travel_times[0] == pytest.approx(expected_tt, rel=1e-6)
@@ -125,7 +130,7 @@ class TestTraceRays:
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([0.0, 0.0, 1500.0])
         result = laytracer.trace_rays(
-            src, rcv, df, compute_amplitude=True, n_jobs=1
+            src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}, n_jobs=1
         )
 
         expected_tt = 500.0 / 3000.0 + 500.0 / 4500.0
@@ -149,7 +154,7 @@ class TestTraceRays:
         src = np.array([100.0, 200.0, 500.0])
         rcv = np.array([100.0, 200.0, 500.0])
         result = laytracer.trace_rays(
-            src, rcv, df, compute_amplitude=True
+            src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"}
         )
         assert result.travel_times[0] == pytest.approx(0.0)
         assert result.tstar[0] == pytest.approx(0.0)
@@ -177,7 +182,7 @@ def test_unpack_results_handles_mixed_none_amplitudes():
         (2.0, np.array([[1.0, 0.0, 0.0]]), 0.2, 0.3, 4.5, None),
     ]
 
-    unpacked = _unpack_results(results, compute_amplitude=True)
+    unpacked = _unpack_results(results, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
 
     np.testing.assert_allclose(unpacked.travel_times, [1.0, 2.0])
     np.testing.assert_allclose(unpacked.tstar, [0.2, 0.3])
@@ -185,3 +190,4 @@ def test_unpack_results_handles_mixed_none_amplitudes():
     assert unpacked.spreading[1] == pytest.approx(4.5)
     assert unpacked.trans_product[0] == pytest.approx(1.0)
     assert np.isnan(unpacked.trans_product[1])
+

--- a/pytests/test_generalized.py
+++ b/pytests/test_generalized.py
@@ -204,7 +204,7 @@ def test_transmission_amplitude():
          receivers=[0,0,1200],
          velocity_df=df,
          source_phase="P",
-         compute_amplitude=True,
+         requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
          transcoef_method="standard"
     )
     
@@ -233,7 +233,7 @@ def test_transmission_normalized():
         receivers=[3000, 0, 2500],
         velocity_df=df,
         source_phase="P",
-        compute_amplitude=True,
+        requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         transcoef_method="standard",
     )
     res_norm = trace_rays(
@@ -241,7 +241,7 @@ def test_transmission_normalized():
         receivers=[3000, 0, 2500],
         velocity_df=df,
         source_phase="P",
-        compute_amplitude=True,
+        requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         transcoef_method="normalized",
     )
 
@@ -262,7 +262,7 @@ def test_transmission_normalized():
 def test_normalized_vertical_ray():
     """At normal incidence (p=0), normalized T equals standard T * sqrt(Z_out/Z_in).
     
-    The Červený (2001) normalization factor at p=0 simplifies to
+    The ??erven?? (2001) normalization factor at p=0 simplifies to
     sqrt(v_out * rho_out / (v_in * rho_in)) = sqrt(Z_out / Z_in).
     """
     from laytracer.amplitude import psv_rt_coefficients, normalize_rt_coefficient
@@ -281,7 +281,7 @@ def test_normalized_vertical_ray():
         receivers=[0, 0, 1500],
         velocity_df=df,
         source_phase="P",
-        compute_amplitude=True,
+        requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         transcoef_method="standard",
     )
     res_norm = trace_rays(
@@ -289,7 +289,7 @@ def test_normalized_vertical_ray():
         receivers=[0, 0, 1500],
         velocity_df=df,
         source_phase="P",
-        compute_amplitude=True,
+        requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         transcoef_method="normalized",
     )
 
@@ -315,3 +315,4 @@ if __name__ == "__main__":
         print(f"Test failed: {e}")
         import traceback
         traceback.print_exc()
+

--- a/pytests/test_homogeneous_equivalence.py
+++ b/pytests/test_homogeneous_equivalence.py
@@ -18,24 +18,24 @@ import pytest
 import laytracer
 
 
-# ── Model parameters (shared by all three approaches) ──────────────────
+# Model parameters (shared by all three approaches)
 
 VP = 5000.0          # P-wave velocity  (m/s)
 VS = VP / 1.732      # S-wave velocity   (m/s)
-RHO = 2700.0         # density           (kg/m³)
+RHO = 2700.0         # density           (kg/m??)
 QP = 500.0           # P-wave quality factor
 QS = 250.0           # S-wave quality factor
 
 # Geometry
-SRC = np.array([0.0, 0.0, 500.0])       # source  (x, y, z) — 500 m depth
-RCV = np.array([5000.0, 0.0, 2500.0])   # receiver (x, y, z) — 2500 m depth
+SRC = np.array([0.0, 0.0, 500.0])       # source  (x, y, z) ??? 500 m depth
+RCV = np.array([5000.0, 0.0, 2500.0])   # receiver (x, y, z) ??? 2500 m depth
 
 EPIC = np.sqrt((RCV[0] - SRC[0]) ** 2 + (RCV[1] - SRC[1]) ** 2)  # 5000 m
 DZ = abs(RCV[2] - SRC[2])                                          # 2000 m
 DIST = np.sqrt(EPIC ** 2 + DZ ** 2)                                # ~5385 m
 
 
-# ── Model DataFrames ───────────────────────────────────────────────────
+# Model DataFrames
 
 def _homo_model() -> pd.DataFrame:
     """Single-layer (homogeneous) model."""
@@ -61,7 +61,7 @@ def _two_layer_identical_model() -> pd.DataFrame:
     })
 
 
-# ── (a) Analytical homogeneous formulas ───────────────────────────────
+# (a) Analytical homogeneous formulas
 
 def _analytical_solution():
     """Closed-form quantities for a straight ray in a homogeneous medium.
@@ -79,14 +79,14 @@ def _analytical_solution():
     # t* (attenuation operator)
     tstar = tt / QP
 
-    # Ray parameter  p = sin(θ) / V = X / (V * R)
+    # Ray parameter  p = sin(??) / V = X / (V * R)
     p = EPIC / (VP * R)
 
-    # Geometrical spreading (relative, Červený convention used in LayTracer)
+    # Geometrical spreading (relative, ??erven?? convention used in LayTracer)
     #   For a homogeneous medium: L = R * V
     spreading = R * VP
 
-    # Transmission coefficient product (no interfaces → 1.0)
+    # Transmission coefficient product (no interfaces ??? 1.0)
     trans_product = 1.0
 
     # Combined amplitude factor  (T / L) * exp(-pi * f * tstar)
@@ -104,7 +104,7 @@ def _analytical_solution():
     )
 
 
-# ── (b) & (c) Code-based solutions ────────────────────────────────────
+# (b) & (c) Code-based solutions
 
 def _run_code(vel_df: pd.DataFrame):
     """Trace one ray through *vel_df* and return the same dict as _analytical_solution."""
@@ -113,7 +113,7 @@ def _run_code(vel_df: pd.DataFrame):
         receivers=RCV,
         velocity_df=vel_df,
         source_phase="P",
-        compute_amplitude=True,
+        requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"},
         transcoef_method="standard",
     )
     tt = float(result.travel_times[0])
@@ -133,14 +133,14 @@ def _run_code(vel_df: pd.DataFrame):
     )
 
 
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 #  Test class
-# ═══════════════════════════════════════════════════════════════════════
+# =====================================================================================================================================================================================================================
 
 class TestHomogeneousEquivalence:
     """All three approaches must agree on every computed quantity."""
 
-    # ── fixtures ──────────────────────────────────────────────────────
+    # fixtures
 
     @pytest.fixture(scope="class")
     def analytical(self):
@@ -154,7 +154,7 @@ class TestHomogeneousEquivalence:
     def layered_code(self):
         return _run_code(_two_layer_identical_model())
 
-    # ── travel time ───────────────────────────────────────────────────
+    # travel time
 
     def test_travel_time_analytical_vs_homo(self, analytical, homo_code):
         """(a) vs (b): travel time."""
@@ -174,7 +174,7 @@ class TestHomogeneousEquivalence:
             homo_code["travel_time"], rel=1e-6
         )
 
-    # ── ray parameter ─────────────────────────────────────────────────
+    # ray parameter 
 
     def test_ray_parameter_analytical_vs_homo(self, analytical, homo_code):
         """(a) vs (b): ray parameter."""
@@ -188,7 +188,7 @@ class TestHomogeneousEquivalence:
             analytical["ray_parameter"], rel=1e-6
         )
 
-    # ── t* ────────────────────────────────────────────────────────────
+    # t*
 
     def test_tstar_analytical_vs_homo(self, analytical, homo_code):
         """(a) vs (b): t*."""
@@ -208,7 +208,7 @@ class TestHomogeneousEquivalence:
             homo_code["tstar"], rel=1e-6
         )
 
-    # ── geometrical spreading ─────────────────────────────────────────
+    # geometrical spreading
 
     def test_spreading_analytical_vs_homo(self, analytical, homo_code):
         """(a) vs (b): geometrical spreading."""
@@ -228,7 +228,7 @@ class TestHomogeneousEquivalence:
             homo_code["spreading"], rel=1e-6
         )
 
-    # ── transmission coefficient product ──────────────────────────────
+    # transmission coefficient product
 
     def test_trans_product_analytical_vs_homo(self, analytical, homo_code):
         """(a) vs (b): transmission coefficient product."""
@@ -248,7 +248,7 @@ class TestHomogeneousEquivalence:
             homo_code["trans_product"], rel=1e-6
         )
 
-    # ── combined amplitude factor (T / L) ─────────────────────────────
+    # combined amplitude factor (T / L)
 
     def test_combined_analytical_vs_homo(self, analytical, homo_code):
         """(a) vs (b): combined deterministic amplitude factor."""
@@ -268,7 +268,7 @@ class TestHomogeneousEquivalence:
             homo_code["combined"], rel=1e-6
         )
 
-    # ── summary print (always runs last) ──────────────────────────────
+    # summary print (always runs last)
 
     def test_zz_summary(self, analytical, homo_code, layered_code):
         """Print a comparison table (always passes)."""
@@ -283,3 +283,4 @@ class TestHomogeneousEquivalence:
             )
         lines.append(sep)
         print("\n" + "\n".join(lines))
+

--- a/pytests/test_symmetry.py
+++ b/pytests/test_symmetry.py
@@ -20,7 +20,7 @@ def _simple_model():
 
 class TestSymmetry:
     def test_traveltime_reciprocity(self):
-        """tt(A→B) = tt(B→A)."""
+        """tt(A???B) = tt(B???A)."""
         df = _simple_model()
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([5000.0, 0.0, 2500.0])
@@ -53,12 +53,12 @@ class TestSymmetry:
         })
         src = np.array([0.0, 0.0, 3000.0])
         rcv = np.array([8000.0, 0.0, 0.0])
-        r_fwd = laytracer.trace_rays(src, rcv, df, compute_amplitude=True)
-        r_rev = laytracer.trace_rays(rcv, src, df, compute_amplitude=True)
+        r_fwd = laytracer.trace_rays(src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
+        r_rev = laytracer.trace_rays(rcv, src, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
         assert r_fwd.tstar[0] == pytest.approx(r_rev.tstar[0], rel=1e-6)
 
     def test_spreading_reciprocity(self):
-        """L(S,R) = L(R,S) (Červený-style invariant)."""
+        """L(S,R) = L(R,S) (??erven??-style invariant)."""
         # Spreading is invariant under source-receiver swap
         df = pd.DataFrame({
             "Depth": [0.0, 1000.0, 2000.0, 3500.0],
@@ -70,12 +70,12 @@ class TestSymmetry:
         })
         src = np.array([0.0, 0.0, 3000.0])
         rcv = np.array([8000.0, 0.0, 0.0])
-        r_fwd = laytracer.trace_rays(src, rcv, df, compute_amplitude=True)
-        r_rev = laytracer.trace_rays(rcv, src, df, compute_amplitude=True)
+        r_fwd = laytracer.trace_rays(src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
+        r_rev = laytracer.trace_rays(rcv, src, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
         assert r_fwd.spreading[0] == pytest.approx(r_rev.spreading[0], rel=1e-5)
 
     def test_ray_path_reversal(self):
-        """Forward ray ≈ flipped reverse ray (geometry invariance)."""
+        """Forward ray ??? flipped reverse ray (geometry invariance)."""
         df = _simple_model()
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([5000.0, 0.0, 2500.0])
@@ -112,8 +112,8 @@ class TestSymmetry:
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([5000.0, 0.0, 2500.0])
 
-        fwd = laytracer.trace_rays(src, rcv, df, compute_amplitude=True)
-        rev = laytracer.trace_rays(rcv, src, df, compute_amplitude=True)
+        fwd = laytracer.trace_rays(src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
+        rev = laytracer.trace_rays(rcv, src, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
 
         T_fwd = fwd.trans_product[0]
         T_rev = rev.trans_product[0]
@@ -155,14 +155,14 @@ class TestSymmetry:
         assert r1.ray_parameters[0] == pytest.approx(r3.ray_parameters[0], rel=1e-6)
 
     def test_translation_invariance(self):
-        """In 1D models, absolute x/y doesn't matter—only relative offset."""
+        """In 1D models, absolute x/y doesn't matter???only relative offset."""
         df = _simple_model()
         src = np.array([0.0, 0.0, 500.0])
         rcv = np.array([5000.0, 0.0, 2500.0])
         shift = np.array([1234.0, -987.0, 0.0])
 
-        r0 = laytracer.trace_rays(src, rcv, df, compute_amplitude=True)
-        rS = laytracer.trace_rays(src + shift, rcv + shift, df, compute_amplitude=True)
+        r0 = laytracer.trace_rays(src, rcv, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
+        rS = laytracer.trace_rays(src + shift, rcv + shift, df, requested={"travel_times", "rays", "ray_parameters", "tstar", "spreading", "trans_product"})
 
         assert r0.travel_times[0] == pytest.approx(rS.travel_times[0], rel=1e-6)
         assert r0.ray_parameters[0] == pytest.approx(rS.ray_parameters[0], rel=1e-6)
@@ -191,3 +191,4 @@ class TestSymmetry:
         # Range and depth should match perfectly
         np.testing.assert_allclose(range1, range2, atol=1e-5)
         np.testing.assert_allclose(path1[:, 2], path2[:, 2], atol=1e-5)
+


### PR DESCRIPTION
### Added

- add explicit `requested={...}` output selection to `trace_rays()` and `solve()`, replacing the coarse amplitude switch (#3)

### Changed

- only build and return ray paths, ray parameters, and path-dependent scalar outputs when explicitly requested (#3)

### Fixed

- fix degenerate direct-ray amplitude outputs for zero-offset vertical rays and
  exact same-point rays (#2)
- make amplitude result packing robust to mixed `None` and finite values (#2)
- add regression tests for degenerate direct-ray amplitude cases (#2)